### PR TITLE
Remove unused Tailwind animations and plugin

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -63,18 +63,6 @@
 }
 
 @layer components {
-  @keyframes wave-animation {
-    0% {
-      background-position: 0% 50%;
-    }
-    50% {
-      background-position: 100% 50%;
-    }
-    100% {
-      background-position: 0% 50%;
-    }
-  }
-
   /* Reusable CTA button styles */
   .btn-cta {
     @apply inline-flex w-fit items-center justify-center gap-2 whitespace-nowrap rounded-[5px] font-medium px-6 py-3 text-base border-2 border-pairup-darkBlue transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 shadow-lg hover:shadow-xl active:shadow-md active:translate-y-[1px];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,5 @@
 
 import type { Config } from "tailwindcss";
-import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -78,50 +77,21 @@ export default {
 				md: 'calc(var(--radius) - 2px)',
 				sm: 'calc(var(--radius) - 4px)'
 			},
-			keyframes: {
-				'accordion-down': {
-					from: {
-						height: '0'
-					},
-					to: {
-						height: 'var(--radix-accordion-content-height)'
-					}
-				},
-				'accordion-up': {
-					from: {
-						height: 'var(--radix-accordion-content-height)'
-					},
-					to: {
-						height: '0'
-					}
-				},
-				'fade-in': {
-					'0%': {
-						opacity: '0',
-						transform: 'translateY(10px)'
-					},
-					'100%': {
-						opacity: '1',
-						transform: 'translateY(0)'
-					}
-				},
-				'slide-in': {
-					'0%': {
-						opacity: '0',
-						transform: 'translateX(-10px)'
-					},
-					'100%': {
-						opacity: '1',
-						transform: 'translateX(0)'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
-				'fade-in': 'fade-in 0.5s ease-out forwards',
-				'slide-in': 'slide-in 0.5s ease-out forwards'
-			},
+                        keyframes: {
+                                'fade-in': {
+                                        '0%': {
+                                                opacity: '0',
+                                                transform: 'translateY(10px)'
+                                        },
+                                        '100%': {
+                                                opacity: '1',
+                                                transform: 'translateY(0)'
+                                        }
+                                }
+                        },
+                        animation: {
+                                'fade-in': 'fade-in 0.5s ease-out forwards'
+                        },
 			fontFamily: {
 				sans: ['Inter', 'sans-serif'],
 				display: ['Poppins', 'sans-serif']
@@ -134,5 +104,5 @@ export default {
 			}
 		}
 	},
-	plugins: [tailwindcssAnimate],
+        plugins: [],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- remove unused accordion and slide animations from the Tailwind configuration
- drop the unused tailwindcss-animate plugin since only the custom fade-in utility remains
- delete the unused wave keyframes from the global stylesheet

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15fa4fb4483219fdde5eee9e25ae3