### PR TITLE
Remove GitHub Pages deployment steps and CNAME file from workflow configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
   id-token: write
 
 concurrency:
@@ -75,25 +74,3 @@ jobs:
           VITE_FIREBASE_VAPID_KEY: ${{ secrets.VITE_FIREBASE_VAPID_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
-
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: dist
-
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-    # Only run if build job actually ran (avoid running on PRs)
-    if: needs.build.result == 'success'
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-pairup-events.com


### PR DESCRIPTION
This pull request removes the GitHub Pages deployment workflow from the project. The main changes are the removal of deployment-related steps from `.github/workflows/deploy.yml` and the deletion of the custom domain configuration file.

**GitHub Actions workflow cleanup:**

* Removed all steps related to configuring, uploading, and deploying to GitHub Pages from the `deploy.yml` workflow, including the `Configure Pages`, `Upload artifact`, and `Deploy to GitHub Pages` jobs.
* Removed the `pages: write` permission from the workflow, as it is no longer needed.

**Domain configuration:**

* Deleted the `public/CNAME` file, which previously set the custom domain for GitHub Pages.